### PR TITLE
Fix CI build failure

### DIFF
--- a/.github/workflows/buildService.yml
+++ b/.github/workflows/buildService.yml
@@ -19,6 +19,21 @@ jobs:
       - name: Checkout services repository
         uses: actions/checkout@v4
 
+      - name: Free up disk space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          echo "Removing unnecessary packages and files..."
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo apt-get clean
+          echo "Disk space after cleanup:"
+          df -h
+        shell: bash
+
       - name: Build the service package
         id: build
         run: |

--- a/.github/workflows/releaseService.yml
+++ b/.github/workflows/releaseService.yml
@@ -17,6 +17,21 @@ jobs:
       - name: Checkout services repository
         uses: actions/checkout@v4
 
+      - name: Free up disk space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          echo "Removing unnecessary packages and files..."
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo apt-get clean
+          echo "Disk space after cleanup:"
+          df -h
+        shell: bash
+
       - name: Build the service package
         run: |
           git submodule update --init --recursive


### PR DESCRIPTION
I noticed the service failed[^2] to build for the last update. 

I asked GH Copilot to look into it and propose a fix. It proposed a PR[^1] which indeed seem to work: with it the CI step `buildPackage` completed[^3] and the `s9pk` bundle was successfully created.

This PR brings those fixes to this repo too. See Copilot's original PR[^1] for a more detailed description of the changes.

[^1]: https://github.com/ok300/freegpt2-startos/pull/1
[^2]: https://github.com/Start9Labs/freegpt2-startos/actions/runs/18035588005/job/51321672821
[^3]: https://github.com/ok300/freegpt2-startos/actions/runs/19328548287