### PR TITLE
chore: bump Ollama 0.11.10→0.18.0, Open WebUI 0.6.30→0.8.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/open-webui/open-webui:0.6.30-ollama
+FROM ghcr.io/open-webui/open-webui:0.8.10-ollama
 
 ADD ./docker_entrypoint.sh /usr/local/bin/docker_entrypoint.sh
 RUN chmod a+x /usr/local/bin/docker_entrypoint.sh

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,13 +1,17 @@
 id: free-gpt
 title: "FreeGPT-2"
-version: 2.01110.0630
+version: 2.01800.0810
 release-notes: |
-  - **Latest Models**: Updated to Ollama 0.11.10 with support for OpenAI's open-weight models (gpt-oss) designed for powerful reasoning, agentic tasks, and versatile developer use cases.
-  - **Better Performance**: Improved memory management and faster model loading times, especially beneficial on systems with sufficient RAM.
-  - **Enhanced Chat Interface**: Completely redesigned chat input with better file attachments, rich text editing, and improved conversation management.
-  - **Improved Stability**: Better OpenAI API compatibility and various bug fixes for more reliable operation.
-  - Ollama - ([changelog](https://github.com/ollama/ollama/releases/tag/v0.11.10))
-  - Open WebUI - ([changelog](https://github.com/open-webui/open-webui/releases/tag/v0.6.30))
+  - **MAJOR UPDATE**: Ollama 0.11.10 → 0.18.0, Open WebUI 0.6.30 → 0.8.10. This is a large jump across both components.
+  - **New Model Support**: Qwen 3.5, LFM 2, Nemotron, and many more model families now supported.
+  - **Thinking & Reasoning**: Improved thinking/reasoning model support with better streaming and tool calling.
+  - **Cloud Models & OpenClaw**: Ollama launch support, cloud model integration, and OpenClaw compatibility.
+  - **Open Terminal**: Open WebUI now includes a file browser, Jupyter notebooks, SQLite browser, and HTML preview.
+  - **Performance**: Massive performance improvements across the board, improved memory management, and faster model loading.
+  - **New Features**: Pyodide file system, nested folders, MariaDB Vector backend, Docker image SBOM attestation.
+  - **MLX & ROCm**: MLX engine improvements and ROCm v7.2 support for AMD GPUs.
+  - Ollama - ([changelog](https://github.com/ollama/ollama/releases/tag/v0.18.0))
+  - Open WebUI - ([changelog](https://github.com/open-webui/open-webui/releases/tag/v0.8.10))
 license: MIT
 wrapper-repo: "https://github.com/Start9Labs/freegpt2-startos"
 upstream-repo: "https://github.com/Start9Labs/freegpt2-startos"


### PR DESCRIPTION
## Summary

**MAJOR upstream update** — both bundled components jump significantly:
- **Ollama**: 0.11.10 → 0.18.0
- **Open WebUI**: 0.6.30 → 0.8.10

Docker image tag: `ghcr.io/open-webui/open-webui:0.6.30-ollama` → `ghcr.io/open-webui/open-webui:0.8.10-ollama`

Package version: `2.01110.0630` → `2.01800.0810`

## Key Ollama changes (0.11.10 → 0.18.0)

- Cloud models, ollama launch support, OpenClaw integration
- New model support: Qwen 3.5, LFM 2, Nemotron, and more
- MLX engine improvements, ROCm v7.2 for AMD GPUs
- Thinking/reasoning model improvements with better streaming and tool calling
- Improved memory management and faster model loading
- Full changelog: https://github.com/ollama/ollama/releases

## Key Open WebUI changes (0.6.30 → 0.8.10)

- **Open Terminal**: File browser, Jupyter notebooks, SQLite browser, HTML preview
- Massive performance improvements across the board
- Pyodide file system, nested folders
- MariaDB Vector backend
- Docker image SBOM attestation
- OIDC custom logout, OAuth profile sync
- Full changelog: https://github.com/open-webui/open-webui/releases

## Proposed new features to consider

Given the scope of this update, the following new capabilities may be worth surfacing to users:

1. **Open Terminal** — Open WebUI's built-in terminal with file browser, Jupyter, and SQLite browser could be valuable for power users. Needs evaluation for StartOS compatibility and security implications.
2. **Cloud model support** — Ollama now supports cloud models. This changes the "entirely offline" value proposition — may want to keep disabled or make configurable.
3. **Reasoning/thinking models** — Improved support for reasoning models (o1-style thinking). Users can now use thinking-capable models more effectively.

## Testing notes

This is a **draft PR** because of the magnitude of the version jump. Before merging:

- [ ] Build the `.s9pk` and verify it packages correctly
- [ ] Fresh install on test server — verify startup, health checks, UI loads
- [ ] Update path from previous version (`2.01110.0630`) — verify migration works
- [ ] Pull and run a model (e.g. `llama3.2`) — verify Ollama backend works
- [ ] Test chat interface — verify Open WebUI frontend works
- [ ] Evaluate Open Terminal feature for StartOS compatibility
- [ ] Evaluate cloud model feature — decide whether to disable/configure