### PR TITLE
add rocm variant with hardware requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
-ARCHES := x86 arm
 # overrides to s9pk.mk must precede the include statement
+TARGETS := generic rocm
+ARCHES := x86 arm
+
 include s9pk.mk
+
+.PHONY += generic rocm
+
+generic:
+	VARIANT=generic $(MAKE) arches
+
+rocm:
+	VARIANT=rocm $(MAKE) arches ARCHES=x86

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -1,6 +1,24 @@
 import { setupManifest } from '@start9labs/start-sdk'
 import { long, short } from './i18n'
 
+const variant = process.env.VARIANT || 'generic'
+
+type Mutable<T> = { -readonly [K in keyof T]: Mutable<T[K]> }
+const mutable = <T>(value: T): Mutable<T> => value as Mutable<T>
+
+const imageConfigs = {
+  generic: {
+    source: { dockerTag: 'ollama/ollama:0.19.0' },
+    arch: ['aarch64', 'x86_64'],
+    nvidiaContainer: true,
+  },
+  rocm: {
+    source: { dockerTag: 'ollama/ollama:0.19.0-rocm' },
+    arch: ['x86_64'],
+    nvidiaContainer: false,
+  },
+} as const
+
 export const manifest = setupManifest({
   id: 'ollama',
   title: 'Ollama',
@@ -13,12 +31,25 @@ export const manifest = setupManifest({
   description: { short, long },
   volumes: ['main'],
   images: {
-    ollama: {
-      source: {
-        dockerTag: 'ollama/ollama:0.19.0',
-      },
-      arch: ['aarch64', 'x86_64'],
-    },
+    ollama: mutable(
+      imageConfigs[variant as keyof typeof imageConfigs] ??
+        imageConfigs.generic,
+    ),
+  },
+  hardwareAcceleration: true,
+  hardwareRequirements: {
+    device:
+      variant === 'rocm'
+        ? [
+            {
+              class: 'display' as const,
+              product: null,
+              vendor: null,
+              driver: 'amdgpu',
+              description: 'An AMD GPU',
+            },
+          ]
+        : [],
   },
   dependencies: {},
 })

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_0_19_0_0 } from './v0.19.0.0'
+import { v_0_19_0_1 } from './v0.19.0.1'
 
 export const versionGraph = VersionGraph.of({
-  current: v_0_19_0_0,
+  current: v_0_19_0_1,
   other: [],
 })

--- a/startos/versions/v0.19.0.1.ts
+++ b/startos/versions/v0.19.0.1.ts
@@ -1,7 +1,7 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
-export const v_0_19_0_0 = VersionInfo.of({
-  version: '0.19.0:0',
+export const v_0_19_0_1 = VersionInfo.of({
+  version: '0.19.0:1',
   releaseNotes: {
     en_US: 'Update Ollama to 0.19.0',
     es_ES: 'Actualización de Ollama a 0.19.0',


### PR DESCRIPTION
## Summary
- Reworks the stale `feature/hardware-requirements` branch (cut at SDK beta.45) on top of current master (SDK 1.1.0).
- Adds a `rocm` build variant using `VARIANT` env var, mirroring the pattern established in vllm-startos.
- Generic variant sets `nvidiaContainer: true`; rocm variant sets `hardwareRequirements.device` to an `amdgpu` display.

## Test plan
- [x] `make generic` builds `ollama_generic_{x86_64,aarch64}.s9pk`
- [x] `make rocm` builds `ollama_rocm_x86_64.s9pk`
- [x] Install generic on NVIDIA host; confirm CUDA libs mount and ollama detects GPU
- [ ] Install rocm on AMD host; confirm AMD GPU detection