### PR TITLE
chore: bump ollama to 0.24.0 and start-sdk to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "ollama-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1"
+        "@start9labs/start-sdk": "1.5.2"
       },
       "devDependencies": {
         "@types/node": "^22.18.6",
@@ -61,9 +61,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1"
+    "@start9labs/start-sdk": "1.5.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.6",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -8,12 +8,12 @@ const mutable = <T>(value: T): Mutable<T> => value as Mutable<T>
 
 const imageConfigs = {
   generic: {
-    source: { dockerTag: 'ollama/ollama:0.23.4' },
+    source: { dockerTag: 'ollama/ollama:0.24.0' },
     arch: ['aarch64', 'x86_64'],
     nvidiaContainer: true,
   },
   rocm: {
-    source: { dockerTag: 'ollama/ollama:0.23.4-rocm' },
+    source: { dockerTag: 'ollama/ollama:0.24.0-rocm' },
     arch: ['x86_64'],
     nvidiaContainer: false,
   },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_0_23_4_0 } from './v0.23.4.0'
+import { v_0_24_0_0 } from './v0.24.0.0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_0_23_4_0,
+  current: v_0_24_0_0,
   other: [],
 })

--- a/startos/versions/v0.24.0.0.ts
+++ b/startos/versions/v0.24.0.0.ts
@@ -1,28 +1,28 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
-export const v_0_23_4_0 = VersionInfo.of({
-  version: '0.23.4:0',
+export const v_0_24_0_0 = VersionInfo.of({
+  version: '0.24.0:0',
   releaseNotes: {
     en_US: `**Bumps**
 
-- Ollama → 0.23.4
-- start-sdk → 1.5.1`,
+- Ollama → 0.24.0
+- start-sdk → 1.5.2`,
     es_ES: `**Cambios de versión**
 
-- Ollama → 0.23.4
-- start-sdk → 1.5.1`,
+- Ollama → 0.24.0
+- start-sdk → 1.5.2`,
     de_DE: `**Versionssprünge**
 
-- Ollama → 0.23.4
-- start-sdk → 1.5.1`,
+- Ollama → 0.24.0
+- start-sdk → 1.5.2`,
     pl_PL: `**Aktualizacje wersji**
 
-- Ollama → 0.23.4
-- start-sdk → 1.5.1`,
+- Ollama → 0.24.0
+- start-sdk → 1.5.2`,
     fr_FR: `**Mises à niveau**
 
-- Ollama → 0.23.4
-- start-sdk → 1.5.1`,
+- Ollama → 0.24.0
+- start-sdk → 1.5.2`,
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

- **Ollama 0.23.4 → 0.24.0.** Upstream's headline changes are the Codex App launcher integration and an MLX sampler rework — both Apple-Silicon / desktop-launcher features that don't reach the Linux container path this package ships. No behavior change for the API server we expose; just a tag bump on `ollama/ollama` (both `generic` and `rocm` variants) and the version-file rename in place.
- **start-sdk 1.5.1 → 1.5.2.** Sole fix is to `Backups.withPgDump` / `Backups.withMysqlDump`; ollama uses neither, so this is a no-op for us — included to stay current with the org pin.

No README / instructions updates: the bump doesn't change any user-visible surface, ports, volumes, actions, or dependencies.

Build verified: all three variants (`generic_x86_64`, `generic_aarch64`, `rocm_x86_64`) pack clean at `0.24.0:0` with SDK 1.5.2.

## Test plan

- [ ] Sideload `ollama_generic_x86_64.s9pk`, confirm it starts and the `Ollama API` health check goes green.
- [ ] Hit `/api/tags` to confirm the API responds.