### PR TITLE
chore: bump Ollama to 0.30.5; 0.30.0:0 → 0.30.5:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -8,12 +8,12 @@ const mutable = <T>(value: T): Mutable<T> => value as Mutable<T>
 
 const imageConfigs = {
   generic: {
-    source: { dockerTag: 'ollama/ollama:0.30.5' },
+    source: { dockerTag: 'ollama/ollama:0.30.6' },
     arch: ['aarch64', 'x86_64'],
     nvidiaContainer: true,
   },
   rocm: {
-    source: { dockerTag: 'ollama/ollama:0.30.5-rocm' },
+    source: { dockerTag: 'ollama/ollama:0.30.6-rocm' },
     arch: ['x86_64'],
     nvidiaContainer: false,
   },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -8,12 +8,12 @@ const mutable = <T>(value: T): Mutable<T> => value as Mutable<T>
 
 const imageConfigs = {
   generic: {
-    source: { dockerTag: 'ollama/ollama:0.30.0' },
+    source: { dockerTag: 'ollama/ollama:0.30.5' },
     arch: ['aarch64', 'x86_64'],
     nvidiaContainer: true,
   },
   rocm: {
-    source: { dockerTag: 'ollama/ollama:0.30.0-rocm' },
+    source: { dockerTag: 'ollama/ollama:0.30.5-rocm' },
     arch: ['x86_64'],
     nvidiaContainer: false,
   },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,53 +1,18 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.30.0:0',
+  version: '0.30.5:0',
   releaseNotes: {
-    en_US: `**Ollama → 0.30.0**
-
-Adds the llama.cpp inference backend alongside the MLX engine: broader hardware support, GGUF models from Hugging Face, and faster performance on NVIDIA GPUs.
-
-**Please note**
-
-- This update cannot be rolled back. Once 0.30.0 is installed you cannot downgrade to 0.24.0.
-- \`nomic-embed-text\` now converts inputs to lowercase (per its model card); embeddings may differ from earlier versions.
-- \`llama3.2-vision\` and \`laguna-xs.2\` are not yet supported on Linux.`,
-    es_ES: `**Ollama → 0.30.0**
-
-Añade el motor de inferencia llama.cpp junto al motor MLX: mayor compatibilidad de hardware, modelos GGUF de Hugging Face y mejor rendimiento en GPU NVIDIA.
-
-**Ten en cuenta**
-
-- Esta actualización no se puede revertir. Una vez instalada la 0.30.0, no podrás volver a la 0.24.0.
-- \`nomic-embed-text\` ahora convierte las entradas a minúsculas (según la ficha del modelo); los embeddings pueden diferir de versiones anteriores.
-- \`llama3.2-vision\` y \`laguna-xs.2\` aún no son compatibles en Linux.`,
-    de_DE: `**Ollama → 0.30.0**
-
-Ergänzt die MLX-Engine um die llama.cpp-Inferenz-Engine: breitere Hardware-Unterstützung, GGUF-Modelle von Hugging Face und schnellere Leistung auf NVIDIA-GPUs.
-
-**Bitte beachten**
-
-- Dieses Update kann nicht rückgängig gemacht werden. Nach der Installation von 0.30.0 ist kein Downgrade auf 0.24.0 mehr möglich.
-- \`nomic-embed-text\` wandelt Eingaben jetzt in Kleinbuchstaben um (gemäß Modellkarte); Embeddings können von früheren Versionen abweichen.
-- \`llama3.2-vision\` und \`laguna-xs.2\` werden unter Linux noch nicht unterstützt.`,
-    pl_PL: `**Ollama → 0.30.0**
-
-Dodaje silnik inferencji llama.cpp obok silnika MLX: szersze wsparcie sprzętowe, modele GGUF z Hugging Face oraz wyższą wydajność na kartach NVIDIA.
-
-**Uwaga**
-
-- Tej aktualizacji nie można cofnąć. Po zainstalowaniu 0.30.0 nie będzie można wrócić do 0.24.0.
-- \`nomic-embed-text\` zamienia teraz dane wejściowe na małe litery (zgodnie z kartą modelu); osadzenia mogą różnić się od wcześniejszych wersji.
-- \`llama3.2-vision\` i \`laguna-xs.2\` nie są jeszcze obsługiwane w systemie Linux.`,
-    fr_FR: `**Ollama → 0.30.0**
-
-Ajoute le moteur d'inférence llama.cpp en complément du moteur MLX : prise en charge matérielle élargie, modèles GGUF de Hugging Face et meilleures performances sur GPU NVIDIA.
-
-**À noter**
-
-- Cette mise à jour est irréversible. Une fois la 0.30.0 installée, vous ne pourrez pas revenir à la 0.24.0.
-- \`nomic-embed-text\` met désormais les entrées en minuscules (conformément à la fiche du modèle) ; les embeddings peuvent différer des versions précédentes.
-- \`llama3.2-vision\` et \`laguna-xs.2\` ne sont pas encore pris en charge sous Linux.`,
+    en_US:
+      'Bumps Ollama → 0.30.5: adds gemma4 model support, refreshes the bundled llama.cpp, and fixes a gemma4:12b crash.',
+    es_ES:
+      'Actualiza Ollama → 0.30.5: añade compatibilidad con el modelo gemma4, actualiza el llama.cpp incluido y corrige un fallo de gemma4:12b.',
+    de_DE:
+      'Aktualisiert Ollama → 0.30.5: ergänzt Unterstützung für das gemma4-Modell, aktualisiert das mitgelieferte llama.cpp und behebt einen gemma4:12b-Absturz.',
+    pl_PL:
+      'Aktualizuje Ollama → 0.30.5: dodaje obsługę modelu gemma4, odświeża dołączony llama.cpp i naprawia awarię gemma4:12b.',
+    fr_FR:
+      'Met à jour Ollama → 0.30.5 : ajoute la prise en charge du modèle gemma4, met à jour le llama.cpp intégré et corrige un plantage de gemma4:12b.',
   },
   migrations: {
     up: async ({ effects }) => {},

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,18 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.30.5:0',
+  version: '0.30.6:0',
   releaseNotes: {
     en_US:
-      'Bumps Ollama → 0.30.5: adds gemma4 model support, refreshes the bundled llama.cpp, and fixes a gemma4:12b crash.',
+      'Bumps Ollama → 0.30.6: adds `ollama launch omp` integration with Oh My Pi and improves MLX embedding quantization on Apple Silicon.',
     es_ES:
-      'Actualiza Ollama → 0.30.5: añade compatibilidad con el modelo gemma4, actualiza el llama.cpp incluido y corrige un fallo de gemma4:12b.',
+      'Actualiza Ollama → 0.30.6: añade la integración de `ollama launch omp` con Oh My Pi y mejora la cuantización de embeddings MLX en Apple Silicon.',
     de_DE:
-      'Aktualisiert Ollama → 0.30.5: ergänzt Unterstützung für das gemma4-Modell, aktualisiert das mitgelieferte llama.cpp und behebt einen gemma4:12b-Absturz.',
+      'Aktualisiert Ollama → 0.30.6: ergänzt die `ollama launch omp`-Integration mit Oh My Pi und verbessert die MLX-Embedding-Quantisierung auf Apple Silicon.',
     pl_PL:
-      'Aktualizuje Ollama → 0.30.5: dodaje obsługę modelu gemma4, odświeża dołączony llama.cpp i naprawia awarię gemma4:12b.',
+      'Aktualizuje Ollama → 0.30.6: dodaje integrację `ollama launch omp` z Oh My Pi i poprawia kwantyzację osadzeń MLX na Apple Silicon.',
     fr_FR:
-      'Met à jour Ollama → 0.30.5 : ajoute la prise en charge du modèle gemma4, met à jour le llama.cpp intégré et corrige un plantage de gemma4:12b.',
+      'Met à jour Ollama → 0.30.6 : ajoute l’intégration de `ollama launch omp` avec Oh My Pi et améliore la quantification des embeddings MLX sur Apple Silicon.',
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

Bumps the wrapped Ollama image from **0.30.0** to **0.30.5** (latest upstream GitHub release). StartOS version: **0.30.0:0 → 0.30.5:0**.

- `startos/manifest/index.ts` — `generic.source.dockerTag` → `ollama/ollama:0.30.5`, `rocm.source.dockerTag` → `ollama/ollama:0.30.5-rocm` (both tags confirmed published on Docker Hub).
- `startos/versions/current.ts` — edited in place: `version: '0.30.5:0'` and one-line release notes in all locales. No new migration, so no historical version file spun off; the existing `down: IMPOSSIBLE` migration on the current node is left as-is.

## What moved upstream (0.30.0 → 0.30.5)

- gemma4 model support (incl. gemma4-12b).
- Bundled llama.cpp refreshed (multiple updates across 0.30.2/0.30.4).
- Fix for a gemma4:12b floating-point-exception crash (0.30.5).
- Assorted launch/integration improvements.

## Other

- `@start9labs/start-sdk` already at latest (1.5.3) — no SDK bump.
- `npm update` ran (no changes).
- README/instructions reference no version numbers or specific models — no doc changes needed.

## Test plan

- [x] `npm run check` (tsc --noEmit) — green.
- [ ] `make` build + sideload verification in review.