### PR TITLE
chore: bump Ollama to 0.30.7; 0.30.6:0 → 0.30.7:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
-      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -105,6 +105,18 @@
       "bin": {
         "ncc": "dist/ncc/cli.js"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/deep-equality-data-structures": {
       "version": "2.0.0",
@@ -247,16 +259,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -8,12 +8,12 @@ const mutable = <T>(value: T): Mutable<T> => value as Mutable<T>
 
 const imageConfigs = {
   generic: {
-    source: { dockerTag: 'ollama/ollama:0.30.7' },
+    source: { dockerTag: 'ollama/ollama:0.30.8' },
     arch: ['aarch64', 'x86_64'],
     nvidiaContainer: true,
   },
   rocm: {
-    source: { dockerTag: 'ollama/ollama:0.30.7-rocm' },
+    source: { dockerTag: 'ollama/ollama:0.30.8-rocm' },
     arch: ['x86_64'],
     nvidiaContainer: false,
   },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -8,12 +8,12 @@ const mutable = <T>(value: T): Mutable<T> => value as Mutable<T>
 
 const imageConfigs = {
   generic: {
-    source: { dockerTag: 'ollama/ollama:0.30.8' },
+    source: { dockerTag: 'ollama/ollama:0.30.9' },
     arch: ['aarch64', 'x86_64'],
     nvidiaContainer: true,
   },
   rocm: {
-    source: { dockerTag: 'ollama/ollama:0.30.8-rocm' },
+    source: { dockerTag: 'ollama/ollama:0.30.9-rocm' },
     arch: ['x86_64'],
     nvidiaContainer: false,
   },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -8,12 +8,12 @@ const mutable = <T>(value: T): Mutable<T> => value as Mutable<T>
 
 const imageConfigs = {
   generic: {
-    source: { dockerTag: 'ollama/ollama:0.30.6' },
+    source: { dockerTag: 'ollama/ollama:0.30.7' },
     arch: ['aarch64', 'x86_64'],
     nvidiaContainer: true,
   },
   rocm: {
-    source: { dockerTag: 'ollama/ollama:0.30.6-rocm' },
+    source: { dockerTag: 'ollama/ollama:0.30.7-rocm' },
     arch: ['x86_64'],
     nvidiaContainer: false,
   },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,18 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.30.7:0',
+  version: '0.30.8:0',
   releaseNotes: {
     en_US:
-      'Bumps Ollama → 0.30.7: aligns the OpenAI-compatible API model list with available model tags and improves `ollama launch` support. Full notes: https://github.com/ollama/ollama/releases/tag/v0.30.7',
+      'Bumps Ollama → 0.30.8: improves prompt caching for better KV cache reuse, fixes `ollama launch` picking the wrong provider, and adds more stable MLX inference plus better recurrent-model support. Full notes: https://github.com/ollama/ollama/releases/tag/v0.30.8',
     es_ES:
-      'Actualiza Ollama → 0.30.7: alinea la lista de modelos de la API compatible con OpenAI con las etiquetas de modelos disponibles y mejora la compatibilidad de `ollama launch`. Notas completas: https://github.com/ollama/ollama/releases/tag/v0.30.7',
+      'Actualiza Ollama → 0.30.8: mejora el almacenamiento en caché de prompts para reutilizar mejor la caché KV, corrige que `ollama launch` eligiera el proveedor equivocado y añade una inferencia MLX más estable y mejor compatibilidad con modelos recurrentes. Notas completas: https://github.com/ollama/ollama/releases/tag/v0.30.8',
     de_DE:
-      'Aktualisiert Ollama → 0.30.7: gleicht die Modellliste der OpenAI-kompatiblen API mit den verfügbaren Modell-Tags ab und verbessert die `ollama launch`-Unterstützung. Vollständige Hinweise: https://github.com/ollama/ollama/releases/tag/v0.30.7',
+      'Aktualisiert Ollama → 0.30.8: verbessert das Prompt-Caching für bessere Wiederverwendung des KV-Caches, behebt die falsche Anbieterauswahl bei `ollama launch` und bietet stabilere MLX-Inferenz sowie bessere Unterstützung rekurrenter Modelle. Vollständige Hinweise: https://github.com/ollama/ollama/releases/tag/v0.30.8',
     pl_PL:
-      'Aktualizuje Ollama → 0.30.7: dopasowuje listę modeli API zgodnego z OpenAI do dostępnych tagów modeli i poprawia obsługę `ollama launch`. Pełne informacje: https://github.com/ollama/ollama/releases/tag/v0.30.7',
+      'Aktualizuje Ollama → 0.30.8: usprawnia buforowanie promptów dla lepszego wykorzystania pamięci podręcznej KV, naprawia wybór niewłaściwego dostawcy przez `ollama launch` oraz zapewnia stabilniejszą inferencję MLX i lepszą obsługę modeli rekurencyjnych. Pełne informacje: https://github.com/ollama/ollama/releases/tag/v0.30.8',
     fr_FR:
-      'Met à jour Ollama → 0.30.7 : aligne la liste des modèles de l’API compatible OpenAI sur les étiquettes de modèles disponibles et améliore la prise en charge de `ollama launch`. Notes complètes : https://github.com/ollama/ollama/releases/tag/v0.30.7',
+      'Met à jour Ollama → 0.30.8 : améliore la mise en cache des prompts pour une meilleure réutilisation du cache KV, corrige la sélection du mauvais fournisseur par `ollama launch` et apporte une inférence MLX plus stable ainsi qu’une meilleure prise en charge des modèles récurrents. Notes complètes : https://github.com/ollama/ollama/releases/tag/v0.30.8',
   },
   migrations: {
     up: async ({ effects }) => {},

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,18 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.30.6:0',
+  version: '0.30.7:0',
   releaseNotes: {
     en_US:
-      'Bumps Ollama → 0.30.6: adds `ollama launch omp` integration with Oh My Pi and improves MLX embedding quantization on Apple Silicon.',
+      'Bumps Ollama → 0.30.7: aligns the OpenAI-compatible API model list with available model tags and improves `ollama launch` support. Full notes: https://github.com/ollama/ollama/releases/tag/v0.30.7',
     es_ES:
-      'Actualiza Ollama → 0.30.6: añade la integración de `ollama launch omp` con Oh My Pi y mejora la cuantización de embeddings MLX en Apple Silicon.',
+      'Actualiza Ollama → 0.30.7: alinea la lista de modelos de la API compatible con OpenAI con las etiquetas de modelos disponibles y mejora la compatibilidad de `ollama launch`. Notas completas: https://github.com/ollama/ollama/releases/tag/v0.30.7',
     de_DE:
-      'Aktualisiert Ollama → 0.30.6: ergänzt die `ollama launch omp`-Integration mit Oh My Pi und verbessert die MLX-Embedding-Quantisierung auf Apple Silicon.',
+      'Aktualisiert Ollama → 0.30.7: gleicht die Modellliste der OpenAI-kompatiblen API mit den verfügbaren Modell-Tags ab und verbessert die `ollama launch`-Unterstützung. Vollständige Hinweise: https://github.com/ollama/ollama/releases/tag/v0.30.7',
     pl_PL:
-      'Aktualizuje Ollama → 0.30.6: dodaje integrację `ollama launch omp` z Oh My Pi i poprawia kwantyzację osadzeń MLX na Apple Silicon.',
+      'Aktualizuje Ollama → 0.30.7: dopasowuje listę modeli API zgodnego z OpenAI do dostępnych tagów modeli i poprawia obsługę `ollama launch`. Pełne informacje: https://github.com/ollama/ollama/releases/tag/v0.30.7',
     fr_FR:
-      'Met à jour Ollama → 0.30.6 : ajoute l’intégration de `ollama launch omp` avec Oh My Pi et améliore la quantification des embeddings MLX sur Apple Silicon.',
+      'Met à jour Ollama → 0.30.7 : aligne la liste des modèles de l’API compatible OpenAI sur les étiquettes de modèles disponibles et améliore la prise en charge de `ollama launch`. Notes complètes : https://github.com/ollama/ollama/releases/tag/v0.30.7',
   },
   migrations: {
     up: async ({ effects }) => {},

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,18 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.30.8:0',
+  version: '0.30.9:0',
   releaseNotes: {
     en_US:
-      'Bumps Ollama → 0.30.8: improves prompt caching for better KV cache reuse, fixes `ollama launch` picking the wrong provider, and adds more stable MLX inference plus better recurrent-model support. Full notes: https://github.com/ollama/ollama/releases/tag/v0.30.8',
+      'Bumps Ollama → 0.30.9: adds support for the Cohere2Moe architecture, fixes the LFM2 parser/renderer when no thinking is emitted, fixes `ollama launch claude` and other agent use cases that only output a single token, and now returns an error when a single message exceeds the context window. Full notes: https://github.com/ollama/ollama/releases/tag/v0.30.9',
     es_ES:
-      'Actualiza Ollama → 0.30.8: mejora el almacenamiento en caché de prompts para reutilizar mejor la caché KV, corrige que `ollama launch` eligiera el proveedor equivocado y añade una inferencia MLX más estable y mejor compatibilidad con modelos recurrentes. Notas completas: https://github.com/ollama/ollama/releases/tag/v0.30.8',
+      'Actualiza Ollama → 0.30.9: añade compatibilidad con la arquitectura Cohere2Moe, corrige el analizador/renderizador LFM2 cuando no se emite razonamiento, corrige `ollama launch claude` y otros casos de uso de agentes que solo generaban un único token, y ahora devuelve un error cuando un solo mensaje supera la ventana de contexto. Notas completas: https://github.com/ollama/ollama/releases/tag/v0.30.9',
     de_DE:
-      'Aktualisiert Ollama → 0.30.8: verbessert das Prompt-Caching für bessere Wiederverwendung des KV-Caches, behebt die falsche Anbieterauswahl bei `ollama launch` und bietet stabilere MLX-Inferenz sowie bessere Unterstützung rekurrenter Modelle. Vollständige Hinweise: https://github.com/ollama/ollama/releases/tag/v0.30.8',
+      'Aktualisiert Ollama → 0.30.9: ergänzt Unterstützung für die Cohere2Moe-Architektur, behebt den LFM2-Parser/Renderer, wenn kein Thinking ausgegeben wird, behebt `ollama launch claude` und andere Agenten-Anwendungsfälle, die nur ein einzelnes Token ausgaben, und gibt nun einen Fehler zurück, wenn eine einzelne Nachricht das Kontextfenster überschreitet. Vollständige Hinweise: https://github.com/ollama/ollama/releases/tag/v0.30.9',
     pl_PL:
-      'Aktualizuje Ollama → 0.30.8: usprawnia buforowanie promptów dla lepszego wykorzystania pamięci podręcznej KV, naprawia wybór niewłaściwego dostawcy przez `ollama launch` oraz zapewnia stabilniejszą inferencję MLX i lepszą obsługę modeli rekurencyjnych. Pełne informacje: https://github.com/ollama/ollama/releases/tag/v0.30.8',
+      'Aktualizuje Ollama → 0.30.9: dodaje obsługę architektury Cohere2Moe, naprawia parser/renderer LFM2, gdy nie jest emitowane myślenie, naprawia `ollama launch claude` i inne zastosowania agentów, które generowały tylko pojedynczy token, oraz zwraca teraz błąd, gdy pojedyncza wiadomość przekracza okno kontekstu. Pełne informacje: https://github.com/ollama/ollama/releases/tag/v0.30.9',
     fr_FR:
-      'Met à jour Ollama → 0.30.8 : améliore la mise en cache des prompts pour une meilleure réutilisation du cache KV, corrige la sélection du mauvais fournisseur par `ollama launch` et apporte une inférence MLX plus stable ainsi qu’une meilleure prise en charge des modèles récurrents. Notes complètes : https://github.com/ollama/ollama/releases/tag/v0.30.8',
+      'Met à jour Ollama → 0.30.9 : ajoute la prise en charge de l’architecture Cohere2Moe, corrige l’analyseur/rendu LFM2 lorsqu’aucun raisonnement n’est émis, corrige `ollama launch claude` et d’autres cas d’usage d’agents qui ne produisaient qu’un seul jeton, et renvoie désormais une erreur lorsqu’un message dépasse la fenêtre de contexte. Notes complètes : https://github.com/ollama/ollama/releases/tag/v0.30.9',
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

Bumps Ollama to the latest upstream release **v0.30.7** (from 0.30.6). StartOS version `0.30.6:0` → `0.30.7:0`.

- `startos/manifest/index.ts` — both Docker tags bumped (`ollama/ollama:0.30.7` and `ollama/ollama:0.30.7-rocm`; both confirmed published to Docker Hub including the lagging `-rocm` variant).
- `startos/versions/current.ts` — in-place edit of `version` + `releaseNotes` (all locales). No migration needed.
- `npm update` floated prettier 3.8.3 → 3.8.4 (dev-only).

## Upstream highlights (v0.30.7)

- `ollama launch hermes-desktop` — native desktop interface for the Hermes agent.
- OpenAI-compatible API models list now aligns with available model tags.
- Docs added describing the llama.cpp update process; Zod schema examples updated to use the native `toJSONSchema` helper.

Full notes: https://github.com/ollama/ollama/releases/tag/v0.30.7
Compare: https://github.com/ollama/ollama/compare/v0.30.6...v0.30.7

## Notes

- start-sdk already at latest (1.5.3) — no bump.
- No new actions/volumes/ports/dependencies; README and instructions need no changes.

## Test plan

- [x] `npm run check` (tsc) passes green.