### PR TITLE
chore: bump Ollama to 0.30.11; 0.30.9:0 → 0.30.11:0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
-      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
       "funding": [
         {
           "type": "github",
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
       "funding": [
         {
           "type": "github",
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.3.tgz",
+      "integrity": "sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
@@ -270,7 +270,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "anynum": "^1.0.0"
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/tr46": {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -8,12 +8,12 @@ const mutable = <T>(value: T): Mutable<T> => value as Mutable<T>
 
 const imageConfigs = {
   generic: {
-    source: { dockerTag: 'ollama/ollama:0.30.9' },
+    source: { dockerTag: 'ollama/ollama:0.30.11' },
     arch: ['aarch64', 'x86_64'],
     nvidiaContainer: true,
   },
   rocm: {
-    source: { dockerTag: 'ollama/ollama:0.30.9-rocm' },
+    source: { dockerTag: 'ollama/ollama:0.30.11-rocm' },
     arch: ['x86_64'],
     nvidiaContainer: false,
   },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,18 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.30.9:0',
+  version: '0.30.11:0',
   releaseNotes: {
     en_US:
-      'Bumps Ollama → 0.30.9: adds support for the Cohere2Moe architecture, fixes the LFM2 parser/renderer when no thinking is emitted, fixes `ollama launch claude` and other agent use cases that only output a single token, and now returns an error when a single message exceeds the context window. Full notes: https://github.com/ollama/ollama/releases/tag/v0.30.9',
+      'Bumps Ollama → 0.30.11 (includes 0.30.10): updates the underlying llama.cpp engine, improves `ollama launch` (auto-installs Claude Code and opencode, adds thinking-capability detection), preserves generation headroom for shifted prompts, and fixes `ollama ps` double-counting mmap’d weights on partial offload. Full notes: https://github.com/ollama/ollama/releases/tag/v0.30.11',
     es_ES:
-      'Actualiza Ollama → 0.30.9: añade compatibilidad con la arquitectura Cohere2Moe, corrige el analizador/renderizador LFM2 cuando no se emite razonamiento, corrige `ollama launch claude` y otros casos de uso de agentes que solo generaban un único token, y ahora devuelve un error cuando un solo mensaje supera la ventana de contexto. Notas completas: https://github.com/ollama/ollama/releases/tag/v0.30.9',
+      'Actualiza Ollama → 0.30.11 (incluye 0.30.10): actualiza el motor llama.cpp subyacente, mejora `ollama launch` (instala automáticamente Claude Code y opencode, añade detección de capacidad de razonamiento), conserva margen de generación para prompts desplazados y corrige que `ollama ps` contara dos veces los pesos mapeados en memoria con descarga parcial. Notas completas: https://github.com/ollama/ollama/releases/tag/v0.30.11',
     de_DE:
-      'Aktualisiert Ollama → 0.30.9: ergänzt Unterstützung für die Cohere2Moe-Architektur, behebt den LFM2-Parser/Renderer, wenn kein Thinking ausgegeben wird, behebt `ollama launch claude` und andere Agenten-Anwendungsfälle, die nur ein einzelnes Token ausgaben, und gibt nun einen Fehler zurück, wenn eine einzelne Nachricht das Kontextfenster überschreitet. Vollständige Hinweise: https://github.com/ollama/ollama/releases/tag/v0.30.9',
+      'Aktualisiert Ollama → 0.30.11 (enthält 0.30.10): aktualisiert die zugrunde liegende llama.cpp-Engine, verbessert `ollama launch` (installiert Claude Code und opencode automatisch, erkennt Thinking-Fähigkeiten), bewahrt Generierungs-Spielraum für verschobene Prompts und behebt die doppelte Zählung von mmap-Gewichten durch `ollama ps` bei teilweiser Auslagerung. Vollständige Hinweise: https://github.com/ollama/ollama/releases/tag/v0.30.11',
     pl_PL:
-      'Aktualizuje Ollama → 0.30.9: dodaje obsługę architektury Cohere2Moe, naprawia parser/renderer LFM2, gdy nie jest emitowane myślenie, naprawia `ollama launch claude` i inne zastosowania agentów, które generowały tylko pojedynczy token, oraz zwraca teraz błąd, gdy pojedyncza wiadomość przekracza okno kontekstu. Pełne informacje: https://github.com/ollama/ollama/releases/tag/v0.30.9',
+      'Aktualizuje Ollama → 0.30.11 (zawiera 0.30.10): aktualizuje silnik llama.cpp, ulepsza `ollama launch` (automatycznie instaluje Claude Code i opencode, wykrywa zdolność myślenia), zachowuje zapas generacji dla przesuniętych promptów oraz naprawia podwójne liczenie wag mmap przez `ollama ps` przy częściowym odciążeniu. Pełne informacje: https://github.com/ollama/ollama/releases/tag/v0.30.11',
     fr_FR:
-      'Met à jour Ollama → 0.30.9 : ajoute la prise en charge de l’architecture Cohere2Moe, corrige l’analyseur/rendu LFM2 lorsqu’aucun raisonnement n’est émis, corrige `ollama launch claude` et d’autres cas d’usage d’agents qui ne produisaient qu’un seul jeton, et renvoie désormais une erreur lorsqu’un message dépasse la fenêtre de contexte. Notes complètes : https://github.com/ollama/ollama/releases/tag/v0.30.9',
+      'Met à jour Ollama → 0.30.11 (inclut 0.30.10) : met à jour le moteur llama.cpp sous-jacent, améliore `ollama launch` (installe automatiquement Claude Code et opencode, ajoute la détection de capacité de raisonnement), préserve la marge de génération pour les prompts décalés et corrige le double comptage par `ollama ps` des poids mmap lors d’un déchargement partiel. Notes complètes : https://github.com/ollama/ollama/releases/tag/v0.30.11',
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

Bumps Ollama **0.30.9 → 0.30.11** (covers the intermediate 0.30.10 release). StartOS version goes `0.30.9:0 → 0.30.11:0`.

- Updated both `imageConfigs` docker tags in `startos/manifest/index.ts` (`ollama/ollama:0.30.11` and `ollama/ollama:0.30.11-rocm`); confirmed both tags are published on Docker Hub.
- Edited `startos/versions/current.ts` in place (no migration) with the new version string and localized release notes.
- `npm update` refreshed `package-lock.json`. start-sdk already pins the latest (`1.5.3`), so no SDK bump.

## Upstream highlights

**0.30.11**
- Updated the underlying llama.cpp engine.
- `ollama launch` improvements: auto-installs Claude Code and opencode when missing, thinking-capability detection for opencode, Codex model-drift detection.
- Preserves generation headroom for shifted prompts; fixes `ollama ps` double-counting mmap'd weights on partial offload; various GPU/Vulkan/CUDA packaging fixes.

**0.30.10**
- Command A and North family models now run on Apple Silicon with the MLX engine.
- Updated the underlying llama.cpp engine; fixed MLX build artifacts.

Full notes: <https://github.com/ollama/ollama/releases/tag/v0.30.11> · <https://github.com/ollama/ollama/releases/tag/v0.30.10>

## Verification

- `npm run check` (tsc typecheck) passes.