### PR TITLE
chore: bump Ollama to 0.31.1; 0.30.11:0 → 0.31.1:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -8,12 +8,12 @@ const mutable = <T>(value: T): Mutable<T> => value as Mutable<T>
 
 const imageConfigs = {
   generic: {
-    source: { dockerTag: 'ollama/ollama:0.30.11' },
+    source: { dockerTag: 'ollama/ollama:0.31.1' },
     arch: ['aarch64', 'x86_64'],
     nvidiaContainer: true,
   },
   rocm: {
-    source: { dockerTag: 'ollama/ollama:0.30.11-rocm' },
+    source: { dockerTag: 'ollama/ollama:0.31.1-rocm' },
     arch: ['x86_64'],
     nvidiaContainer: false,
   },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,18 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.30.11:0',
+  version: '0.31.1:0',
   releaseNotes: {
     en_US:
-      'Bumps Ollama → 0.30.11 (includes 0.30.10): Command A and North family models now run on Apple Silicon via the MLX engine, the underlying llama.cpp engine is updated, and agent launching is improved (auto-install Claude Code/opencode, thinking-capability detection) alongside several GPU/memory and inference fixes. Full notes: https://github.com/ollama/ollama/releases/tag/v0.30.11',
+      'Bumps Ollama → 0.31.1: the underlying llama.cpp engine is updated (build 9840), the MLX engine gains a new small-batch matmul kernel, and Gemma 4 model loading and multi-token-prediction performance are improved. Full notes: https://github.com/ollama/ollama/releases/tag/v0.31.1',
     es_ES:
-      'Actualiza Ollama → 0.30.11 (incluye 0.30.10): los modelos de las familias Command A y North ahora funcionan en Apple Silicon mediante el motor MLX, se actualiza el motor llama.cpp subyacente y se mejora el lanzamiento de agentes (instalación automática de Claude Code/opencode, detección de capacidad de razonamiento), junto con varias correcciones de GPU/memoria e inferencia. Notas completas: https://github.com/ollama/ollama/releases/tag/v0.30.11',
+      'Actualiza Ollama → 0.31.1: se actualiza el motor llama.cpp subyacente (build 9840), el motor MLX incorpora un nuevo kernel de multiplicación de matrices para lotes pequeños y se mejoran la carga del modelo Gemma 4 y el rendimiento de la predicción de múltiples tokens. Notas completas: https://github.com/ollama/ollama/releases/tag/v0.31.1',
     de_DE:
-      'Aktualisiert Ollama → 0.30.11 (enthält 0.30.10): Modelle der Command-A- und North-Familie laufen nun über die MLX-Engine auf Apple Silicon, die zugrunde liegende llama.cpp-Engine wurde aktualisiert, und der Agenten-Start wurde verbessert (automatische Installation von Claude Code/opencode, Erkennung der Thinking-Fähigkeit), zusammen mit mehreren GPU-/Speicher- und Inferenz-Korrekturen. Vollständige Hinweise: https://github.com/ollama/ollama/releases/tag/v0.30.11',
+      'Aktualisiert Ollama → 0.31.1: Die zugrunde liegende llama.cpp-Engine wurde aktualisiert (Build 9840), die MLX-Engine erhält einen neuen Matmul-Kernel für kleine Batches, und das Laden des Gemma-4-Modells sowie die Multi-Token-Prediction-Leistung wurden verbessert. Vollständige Hinweise: https://github.com/ollama/ollama/releases/tag/v0.31.1',
     pl_PL:
-      'Aktualizuje Ollama → 0.30.11 (zawiera 0.30.10): modele z rodzin Command A i North działają teraz na Apple Silicon dzięki silnikowi MLX, zaktualizowano bazowy silnik llama.cpp oraz ulepszono uruchamianie agentów (automatyczna instalacja Claude Code/opencode, wykrywanie zdolności myślenia), wraz z kilkoma poprawkami GPU/pamięci i wnioskowania. Pełne informacje: https://github.com/ollama/ollama/releases/tag/v0.30.11',
+      'Aktualizuje Ollama → 0.31.1: zaktualizowano bazowy silnik llama.cpp (build 9840), silnik MLX otrzymał nowe jądro mnożenia macierzy dla małych partii, a ładowanie modelu Gemma 4 oraz wydajność predykcji wielu tokenów zostały ulepszone. Pełne informacje: https://github.com/ollama/ollama/releases/tag/v0.31.1',
     fr_FR:
-      'Met à jour Ollama → 0.30.11 (inclut 0.30.10) : les modèles des familles Command A et North fonctionnent désormais sur Apple Silicon via le moteur MLX, le moteur llama.cpp sous-jacent est mis à jour, et le lancement d’agents est amélioré (installation automatique de Claude Code/opencode, détection de la capacité de raisonnement), avec plusieurs correctifs GPU/mémoire et d’inférence. Notes complètes : https://github.com/ollama/ollama/releases/tag/v0.30.11',
+      'Met à jour Ollama → 0.31.1 : le moteur llama.cpp sous-jacent est mis à jour (build 9840), le moteur MLX gagne un nouveau noyau matmul pour petits lots, et le chargement du modèle Gemma 4 ainsi que les performances de prédiction multi-tokens sont améliorés. Notes complètes : https://github.com/ollama/ollama/releases/tag/v0.31.1',
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Summary

Bumps Ollama from 0.30.11 to **0.31.1** (StartOS version `0.30.11:0` → `0.31.1:0`).

Upstream changes since 0.30.11 (v0.31.1 release):
- Underlying llama.cpp engine updated to build 9840.
- MLX engine updated with a new small-batch matmul kernel.
- Improved Gemma 4 MoE model loading and multi-token-prediction (MTP) performance (notable speedups on Apple Silicon, not applicable to StartOS Linux hosts but harmless).

Full upstream notes: https://github.com/ollama/ollama/releases/tag/v0.31.1

## Changes
- `startos/manifest/index.ts` — `generic` and `rocm` docker tags → `ollama/ollama:0.31.1` / `ollama/ollama:0.31.1-rocm` (both confirmed published on Docker Hub).
- `startos/versions/current.ts` — edited in place: `version` `0.31.1:0`, release notes updated in all locales. No migration required.

start-sdk is already at the latest published version (1.5.3); no SDK bump. `npm update` produced no changes.

## Test plan
- [x] `npm run check` (tsc) passes.
- [ ] `make` / s9pk pack (deferred to review).