### PR TITLE
fix: offer ROCm variant only to discrete AMD GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ## Table of Contents
 
 - [Image and Container Runtime](#image-and-container-runtime)
+- [Hardware Acceleration](#hardware-acceleration)
 - [Volume and Data Layout](#volume-and-data-layout)
 - [Installation and First-Run Flow](#installation-and-first-run-flow)
 - [Configuration Management](#configuration-management)
@@ -34,18 +35,31 @@
 
 ## Image and Container Runtime
 
-| Property | Value |
-|----------|-------|
-| Image | `ollama/ollama` (upstream unmodified) |
-| Architectures | x86_64, aarch64 |
-| Entrypoint | Default upstream entrypoint |
+| Property      | Value                                 |
+| ------------- | ------------------------------------- |
+| Image         | `ollama/ollama` (upstream unmodified) |
+| Architectures | x86_64, aarch64                       |
+| Entrypoint    | Default upstream entrypoint           |
+
+---
+
+## Hardware Acceleration
+
+Ollama uses your GPU automatically when the host has a supported one; otherwise it runs on CPU. Only the image differs between variants, and StartOS selects the right one from the detected hardware — there is no manual picker.
+
+| Variant             | Image                         | Auto-selected for                                                                                           |
+| ------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `generic` (default) | `ollama/ollama`               | Any host. Runs on CPU, and uses an **NVIDIA** GPU when the host has one (via the NVIDIA container runtime). |
+| `rocm`              | `ollama/ollama` (`-rocm` tag) | Hosts with a **discrete** AMD GPU (`amdgpu` driver — Navi / Radeon RX / Instinct).                          |
+
+**AMD GPUs — discrete only:** ROCm is unreliable on integrated Radeon graphics (e.g. the Radeon 680M in Ryzen APUs), so the `rocm` variant is offered only to discrete AMD GPUs, matched by product name. Integrated-Radeon hosts fall back to the `generic` variant (CPU, or NVIDIA if also present). A discrete AMD card StartOS doesn't recognize by product name also falls back — sideload the `-rocm` `.s9pk` manually if you need ROCm on such a card.
 
 ---
 
 ## Volume and Data Layout
 
-| Volume | Mount Point | Purpose |
-|--------|-------------|---------|
+| Volume | Mount Point     | Purpose                                    |
+| ------ | --------------- | ------------------------------------------ |
 | `main` | `/root/.ollama` | All Ollama data (models, blobs, manifests) |
 
 **Key directories on the `main` volume:**
@@ -56,11 +70,11 @@
 
 ## Installation and First-Run Flow
 
-| Step | Upstream | StartOS |
-|------|----------|---------|
-| Installation | `curl -fsSL https://ollama.com/install.sh \| sh` | Install from marketplace or sideload `.s9pk` |
-| Start service | `ollama serve` | Automatic via StartOS |
-| Pull models | `ollama pull <model>` | Use API or a connected UI (e.g. Open WebUI) |
+| Step          | Upstream                                         | StartOS                                      |
+| ------------- | ------------------------------------------------ | -------------------------------------------- |
+| Installation  | `curl -fsSL https://ollama.com/install.sh \| sh` | Install from marketplace or sideload `.s9pk` |
+| Start service | `ollama serve`                                   | Automatic via StartOS                        |
+| Pull models   | `ollama pull <model>`                            | Use API or a connected UI (e.g. Open WebUI)  |
 
 **Key difference:** On StartOS, the Ollama API is exposed as a network interface. Use a compatible client or UI service (such as Open WebUI) to interact with it.
 
@@ -83,9 +97,9 @@ Ollama on StartOS runs with default upstream configuration. No user-configurable
 
 ## Network Access and Interfaces
 
-| Interface | Port | Protocol | Type | Purpose |
-|-----------|------|----------|------|---------|
-| Ollama API | 11434 | HTTP | API | Model inference and management API |
+| Interface  | Port  | Protocol | Type | Purpose                            |
+| ---------- | ----- | -------- | ---- | ---------------------------------- |
+| Ollama API | 11434 | HTTP     | API  | Model inference and management API |
 
 **Access methods (StartOS 0.4.0):**
 
@@ -96,14 +110,14 @@ Ollama on StartOS runs with default upstream configuration. No user-configurable
 
 **API endpoints (subset):**
 
-| Endpoint | Method | Purpose |
-|----------|--------|---------|
-| `/api/generate` | POST | Generate text completion |
-| `/api/chat` | POST | Chat completion |
-| `/api/pull` | POST | Download a model |
-| `/api/tags` | GET | List local models |
-| `/api/show` | POST | Show model info |
-| `/api/delete` | DELETE | Remove a model |
+| Endpoint        | Method | Purpose                  |
+| --------------- | ------ | ------------------------ |
+| `/api/generate` | POST   | Generate text completion |
+| `/api/chat`     | POST   | Chat completion          |
+| `/api/pull`     | POST   | Download a model         |
+| `/api/tags`     | GET    | List local models        |
+| `/api/show`     | POST   | Show model info          |
+| `/api/delete`   | DELETE | Remove a model           |
 
 ---
 
@@ -136,9 +150,9 @@ None. Ollama is a standalone application.
 
 ## Health Checks
 
-| Check | Method | Grace Period |
-|-------|--------|--------------|
-| Ollama API | Port listening on 11434 | Default |
+| Check      | Method                  | Grace Period |
+| ---------- | ----------------------- | ------------ |
+| Ollama API | Port listening on 11434 | Default      |
 
 **Messages:**
 
@@ -149,11 +163,10 @@ None. Ollama is a standalone application.
 
 ## Limitations and Differences
 
-1. **No GPU passthrough** -- StartOS does not currently support GPU passthrough, so inference runs on CPU only
+1. **GPU acceleration needs a supported GPU** -- NVIDIA GPUs are used via the default variant (NVIDIA container runtime); discrete AMD GPUs via the auto-selected `rocm` variant. Integrated AMD graphics and hosts with no supported GPU run on CPU, which is significantly slower on larger models. See [Hardware Acceleration](#hardware-acceleration).
 2. **No exposed configuration** -- environment variables and runtime settings cannot be changed through StartOS
 3. **Large storage requirements** -- models are stored on-device and can consume significant disk space (4-5 GB per 7B model)
 4. **Memory requirements** -- 8 GB RAM minimum for 7B models, 16 GB for 13B, 32 GB for 33B+
-5. **CPU-only performance** -- without GPU acceleration, inference is significantly slower than GPU-accelerated setups
 
 ---
 
@@ -185,6 +198,9 @@ image: ollama/ollama
 architectures:
   - x86_64
   - aarch64
+variants: # auto-selected by StartOS from detected GPU
+  - generic # CPU, plus NVIDIA GPU when present
+  - rocm # discrete AMD GPU only (integrated Radeon falls back to generic)
 volumes:
   main: /root/.ollama
 ports:

--- a/instructions.md
+++ b/instructions.md
@@ -41,5 +41,5 @@ Models are pulled by your client (Open WebUI's UI, the `ollama` CLI, or a librar
 
 ## Limitations
 
-- **No GPU acceleration.** This package runs Ollama on CPU only. Inference works but is materially slower than GPU-accelerated setups; expect noticeable latency on larger models. A separate `rocm` variant is auto-selected for hosts with a supported **discrete** AMD GPU; integrated Radeon graphics (such as the Radeon 680M in many Ryzen mini-PCs) are not eligible and fall back to the default variant.
+- **GPU acceleration depends on your hardware.** StartOS uses your GPU automatically when the host has a supported one — an NVIDIA GPU (via the default variant, using the NVIDIA container runtime) or a **discrete** AMD GPU (via the auto-selected `rocm` variant). Integrated AMD graphics (such as the Radeon 680M in many Ryzen mini-PCs) and hosts with no supported GPU run on CPU: inference still works but is materially slower on larger models.
 - **No upstream environment variables exposed.** `OLLAMA_HOST`, `OLLAMA_MODELS`, `OLLAMA_NUM_PARALLEL`, `OLLAMA_MAX_LOADED_MODELS`, and GPU/CUDA tuning all use upstream defaults; they cannot be changed from StartOS.

--- a/instructions.md
+++ b/instructions.md
@@ -41,5 +41,5 @@ Models are pulled by your client (Open WebUI's UI, the `ollama` CLI, or a librar
 
 ## Limitations
 
-- **No GPU acceleration.** This package runs Ollama on CPU only. Inference works but is materially slower than GPU-accelerated setups; expect noticeable latency on larger models. A separate `rocm` variant exists for AMD GPUs but requires a supported AMD card attached to the StartOS host.
+- **No GPU acceleration.** This package runs Ollama on CPU only. Inference works but is materially slower than GPU-accelerated setups; expect noticeable latency on larger models. A separate `rocm` variant is auto-selected for hosts with a supported **discrete** AMD GPU; integrated Radeon graphics (such as the Radeon 680M in many Ryzen mini-PCs) are not eligible and fall back to the default variant.
 - **No upstream environment variables exposed.** `OLLAMA_HOST`, `OLLAMA_MODELS`, `OLLAMA_NUM_PARALLEL`, `OLLAMA_MAX_LOADED_MODELS`, and GPU/CUDA tuning all use upstream defaults; they cannot be changed from StartOS.

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -43,10 +43,13 @@ export const manifest = setupManifest({
         ? [
             {
               class: 'display' as const,
-              product: null,
+              // Discrete-AMD allowlist: ROCm crashes on integrated Radeon (e.g. 680M); iGPUs lack these product names and fall back to the generic variant.
+              product:
+                '(?i)(Navi\\s*\\d+|Radeon\\s*RX\\s*\\d{3}|Radeon\\s*RX\\s*Vega|Radeon\\s*VII|Instinct)',
               vendor: null,
               driver: 'amdgpu',
-              description: 'An AMD GPU',
+              description:
+                'A discrete AMD GPU supported by ROCm (integrated Radeon graphics are not supported)',
             },
           ]
         : [],

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -19,6 +19,28 @@ const imageConfigs = {
   },
 } as const
 
+// ROCm is unreliable on integrated Radeon (e.g. the 680M in Ryzen APUs), so
+// match only discrete AMD GPUs by product name. StartOS's regex engine has no
+// lookahead, so this is a positive allowlist rather than an iGPU exclusion.
+const AMD_DISCRETE_GPU =
+  '(?i)(Navi\\s*\\d+|Radeon\\s*RX\\s*\\d{3}|Radeon\\s*RX\\s*Vega|Radeon\\s*VII|Instinct)'
+
+// hardwareRequirements per accelerator variant. StartOS auto-selects the most
+// hardware-specific compatible variant per host; variants without an entry here
+// (the default) carry no device requirement and act as the CPU fallback.
+const hwDevices = {
+  rocm: [
+    {
+      class: 'display' as const,
+      product: AMD_DISCRETE_GPU,
+      vendor: null,
+      driver: 'amdgpu',
+      description:
+        'A discrete AMD GPU supported by ROCm (integrated Radeon graphics are not supported)',
+    },
+  ],
+} as const
+
 export const manifest = setupManifest({
   id: 'ollama',
   title: 'Ollama',
@@ -38,21 +60,7 @@ export const manifest = setupManifest({
   },
   hardwareAcceleration: true,
   hardwareRequirements: {
-    device:
-      variant === 'rocm'
-        ? [
-            {
-              class: 'display' as const,
-              // Discrete-AMD allowlist: ROCm crashes on integrated Radeon (e.g. 680M); iGPUs lack these product names and fall back to the generic variant.
-              product:
-                '(?i)(Navi\\s*\\d+|Radeon\\s*RX\\s*\\d{3}|Radeon\\s*RX\\s*Vega|Radeon\\s*VII|Instinct)',
-              vendor: null,
-              driver: 'amdgpu',
-              description:
-                'A discrete AMD GPU supported by ROCm (integrated Radeon graphics are not supported)',
-            },
-          ]
-        : [],
+    device: [...(hwDevices[variant as keyof typeof hwDevices] ?? [])],
   },
   dependencies: {},
 })

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,18 @@
 import { VersionInfo, IMPOSSIBLE } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.31.1:0',
+  version: '0.31.1:1',
   releaseNotes: {
     en_US:
-      'Updated Ollama → 0.31.1 (from 0.30.11). Highlights: Gemma 4 runs significantly faster on Apple Silicon — up to ~90% faster token generation via multi-token prediction (MTP), on by default with no configuration and no change to output; the MLX engine is updated with a new small-batch matmul kernel and tightened Gemma 4 MoE loading; the underlying llama.cpp engine is updated to build 9840; and tool-call parsing now ignores braces inside JSON strings. Full notes: https://github.com/ollama/ollama/releases/tag/v0.31.1',
+      'The AMD GPU (ROCm) variant is now offered only to discrete AMD GPUs. Servers whose only AMD graphics are integrated (such as the Radeon 680M in many Ryzen mini-PCs), where ROCm is unreliable, now use the default variant instead.',
     es_ES:
-      'Actualiza Ollama → 0.31.1 (desde 0.30.11). Novedades: Gemma 4 funciona mucho más rápido en Apple Silicon —hasta ~90 % más rápido en la generación de tokens mediante la predicción de múltiples tokens (MTP), activada por defecto, sin configuración y sin cambiar la salida—; el motor MLX se actualiza con un nuevo kernel de multiplicación de matrices para lotes pequeños y una carga optimizada de los modelos MoE de Gemma 4; el motor llama.cpp subyacente se actualiza a la compilación 9840; y el análisis de llamadas a herramientas ahora ignora las llaves dentro de cadenas JSON. Notas completas: https://github.com/ollama/ollama/releases/tag/v0.31.1',
+      'La variante de GPU AMD (ROCm) ahora solo se ofrece a GPU AMD dedicadas. Los servidores cuyos únicos gráficos AMD son integrados (como la Radeon 680M de muchos mini-PC Ryzen), donde ROCm no es fiable, ahora usan la variante predeterminada.',
     de_DE:
-      'Aktualisiert Ollama → 0.31.1 (von 0.30.11). Highlights: Gemma 4 läuft auf Apple Silicon deutlich schneller – bis zu ~90 % schnellere Token-Generierung durch Multi-Token-Prediction (MTP), standardmäßig aktiviert, ohne Konfiguration und ohne Änderung der Ausgabe; die MLX-Engine wurde mit einem neuen Small-Batch-Matmul-Kernel und optimiertem Laden der Gemma-4-MoE-Modelle aktualisiert; die zugrunde liegende llama.cpp-Engine wurde auf Build 9840 aktualisiert; und das Parsen von Tool-Aufrufen ignoriert nun geschweifte Klammern innerhalb von JSON-Zeichenketten. Vollständige Hinweise: https://github.com/ollama/ollama/releases/tag/v0.31.1',
+      'Die AMD-GPU-Variante (ROCm) wird jetzt nur noch für dedizierte AMD-GPUs angeboten. Server, deren einzige AMD-Grafik integriert ist (etwa die Radeon 680M in vielen Ryzen-Mini-PCs), wo ROCm unzuverlässig ist, nutzen nun die Standardvariante.',
     pl_PL:
-      'Aktualizuje Ollama → 0.31.1 (z 0.30.11). Najważniejsze zmiany: Gemma 4 działa znacznie szybciej na Apple Silicon — nawet ~90% szybsze generowanie tokenów dzięki predykcji wielu tokenów (MTP), włączonej domyślnie, bez konfiguracji i bez zmiany wyników; silnik MLX zaktualizowano o nowe jądro mnożenia macierzy dla małych partii oraz zoptymalizowane ładowanie modeli MoE Gemma 4; bazowy silnik llama.cpp zaktualizowano do kompilacji 9840; a analiza wywołań narzędzi ignoruje teraz nawiasy klamrowe wewnątrz łańcuchów JSON. Pełne informacje: https://github.com/ollama/ollama/releases/tag/v0.31.1',
+      'Wariant GPU AMD (ROCm) jest teraz oferowany tylko dla dedykowanych układów AMD. Serwery, których jedyna grafika AMD jest zintegrowana (np. Radeon 680M w wielu mini-PC Ryzen), gdzie ROCm jest niestabilny, korzystają teraz z wariantu domyślnego.',
     fr_FR:
-      'Met à jour Ollama → 0.31.1 (depuis 0.30.11). Points forts : Gemma 4 fonctionne beaucoup plus vite sur Apple Silicon — jusqu’à ~90 % de génération de tokens en plus grâce à la prédiction multi-tokens (MTP), activée par défaut, sans configuration et sans modifier la sortie ; le moteur MLX est mis à jour avec un nouveau noyau matmul pour petits lots et un chargement optimisé des modèles MoE de Gemma 4 ; le moteur llama.cpp sous-jacent passe au build 9840 ; et l’analyse des appels d’outils ignore désormais les accolades à l’intérieur des chaînes JSON. Notes complètes : https://github.com/ollama/ollama/releases/tag/v0.31.1',
+      "La variante GPU AMD (ROCm) n'est désormais proposée qu'aux GPU AMD dédiés. Les serveurs dont la seule puce graphique AMD est intégrée (comme la Radeon 680M de nombreux mini-PC Ryzen), où ROCm est peu fiable, utilisent maintenant la variante par défaut.",
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
Same fix as immich-startos#9, applied to Ollama (found in the follow-up ecosystem sweep).

## Problem

Ollama's `rocm` variant declared `hardwareRequirements.device` matching only `driver: 'amdgpu'`, with `product`/`vendor` null. The `amdgpu` kernel driver binds **integrated** Radeon graphics as well as discrete cards, and StartOS auto-selects the most hardware-specific compatible variant. So any host whose only GPU is an integrated Radeon (e.g. the 680M in Ryzen APUs) silently got the ROCm image, where ROCm/MIGraphX is unreliable on unsupported iGPUs.

## Fix

Narrow `rocm`'s device filter with a discrete-AMD product-name allowlist:

```
(?i)(Navi\s*\d+|Radeon\s*RX\s*\d{3}|Radeon\s*RX\s*Vega|Radeon\s*VII|Instinct)
```

Discrete cards (`Navi 31 [Radeon RX 7900 XTX]`, `Instinct MI250`, …) match; integrated parts (`Rembrandt [Radeon 680M]`, `Phoenix1`, …) don't and fall back to the default variant. Validated against 31 real lshw product strings (16 discrete / 15 integrated) via ripgrep (same Rust `regex` engine StartOS uses) — all classified correctly. Version `0.31.1:0` → `0.31.1:1`.

## Notes

- **Version collision with #25:** the open start-sdk-2.0 PR (#25, branch `next`) also bumps to `0.31.1:1`. Mirroring the immich sequencing: this hotfix should take `:1` on master, then `next` gets rebased and leapfrogged to `:2`. I can do that rebase after this merges.
- **Stale GPU docs (pre-existing, not touched here):** README ("No GPU passthrough — inference runs on CPU only") and instructions ("No GPU acceleration") contradict the fact that the package ships `rocm` + `nvidiaContainer` GPU variants. I corrected only the one instructions sentence that directly describes the `rocm` variant; the broader GPU-support narrative needs a separate, verified pass.

## Testing

`tsc --noEmit` ✓, `prettier --check` ✓, regex validated via ripgrep. No VM testing (per maintainer); CI builds the variants.
